### PR TITLE
gha: Allow the controller to watch Secrets / ConfigMaps in the single namespace mode

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_controller_role.yaml
@@ -47,6 +47,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_single_namespace_watch_role.yaml
@@ -108,6 +108,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -911,7 +911,7 @@ func TestTemplate_CreateManagerSingleNamespaceRole(t *testing.T) {
 
 	assert.Equal(t, "test-arc-gha-rs-controller-single-namespace", managerSingleNamespaceControllerRole.Name)
 	assert.Equal(t, namespaceName, managerSingleNamespaceControllerRole.Namespace)
-	assert.Equal(t, 10, len(managerSingleNamespaceControllerRole.Rules))
+	assert.Equal(t, 12, len(managerSingleNamespaceControllerRole.Rules))
 
 	output = helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/manager_single_namespace_watch_role.yaml"})
 
@@ -920,7 +920,7 @@ func TestTemplate_CreateManagerSingleNamespaceRole(t *testing.T) {
 
 	assert.Equal(t, "test-arc-gha-rs-controller-single-namespace-watch", managerSingleNamespaceWatchRole.Name)
 	assert.Equal(t, "demo", managerSingleNamespaceWatchRole.Namespace)
-	assert.Equal(t, 14, len(managerSingleNamespaceWatchRole.Rules))
+	assert.Equal(t, 16, len(managerSingleNamespaceWatchRole.Rules))
 }
 
 func TestTemplate_ManagerSingleNamespaceRoleBinding(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -234,6 +234,16 @@ func main() {
 	cfg.QPS = float32(rateLimiterQPS)
 	cfg.Burst = rateLimiterBurst
 
+	clientOptions := client.Options{}
+	if watchSingleNamespace == "" {
+		clientOptions.Cache = &client.CacheOptions{
+			DisableFor: []client.Object{
+				&corev1.Secret{},
+				&corev1.ConfigMap{},
+			},
+		}
+	}
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -246,14 +256,7 @@ func main() {
 		WebhookServer:    webhookServer,
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: leaderElectionId,
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.Secret{},
-					&corev1.ConfigMap{},
-				},
-			},
-		},
+		Client:           clientOptions,
 		PprofBindAddress: pprofAddr,
 	})
 	if err != nil {


### PR DESCRIPTION
## WHAT

- Allow the controller to watch Secrets / ConfigMaps in the single namespace mode.
- Enable the k8s API client cache for Secrets / ConfigMaps in the single namespace mode.

## WHY

The EphemeralRunnerReconciler [retrieves](https://github.com/actions/actions-runner-controller/blob/8b36ea90ebe81710fcdcb4f96424b43203d24f1e/controllers/actions.github.com/ephemeralrunner_controller.go#L184-L193) a JITConfig Secret for every reconciliation once the Secret is created for a reconciling runner. It can be a performance bottleneck because the cache of the k8s API client is [disabled](https://github.com/actions/actions-runner-controller/blob/8b36ea90ebe81710fcdcb4f96424b43203d24f1e/main.go#L229-L236) for Secrets, and the client has a rate limiter with QPS=20.

The cache is disabled for Secrets because it requires cluster-wide list/watch permissions in the default mode. But in the single namespace mode, we can narrow down the permissions only to the single namespace and the controller namespace, which would be acceptable.

This change is aligned with [ADR 2023-04-11: Limit Permissions for Service Accounts in Actions-Runner-Controller](https://github.com/actions/actions-runner-controller/blob/master/docs/adrs/2023-04-11-limit-manager-role-permission.md#user-content-fn-1-e815e9ff5813b4c89ea144e793e80598).

> In this mode, you will end up with a manager `Role` that has all Get/List/Create/Delete/Update/Patch/Watch permissions on resources we need, and a `RoleBinding` to bind the `Role` with the controller `ServiceAccount` in the watched single namespace and the controller namespace