### PR TITLE
Add an option for disabling the workqueue bucket rate limiter

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
         {{- with .Values.flags.clientGoRateLimiterBurst }}
         - "--client-go-rate-limiter-burst={{ . }}"
         {{- end }}
+        {{- with .Values.flags.disableWorkqueueBucketRateLimiter }}
+        - "--disable-workqueue-bucket-rate-limiter={{ . }}"
+        {{- end }}
         command:
         - "/manager"
         {{- if or .Values.metrics .Values.pprof }}

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -144,3 +144,4 @@ flags:
   ## Defines the client-go rate limiter parameters.
   # clientGoRateLimiterQPS: 20
   # clientGoRateLimiterBurst: 30
+  # disableWorkqueueBucketRateLimiter: false

--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -32,6 +32,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -81,6 +82,7 @@ type AutoscalingRunnerSetReconciler struct {
 	UpdateStrategy                                UpdateStrategy
 	ActionsClient                                 actions.MultiClient
 	MaxConcurrentReconciles                       int
+	WorkqueueRateLimiter                          workqueue.RateLimiter
 	ResourceBuilder
 }
 
@@ -765,7 +767,10 @@ func (r *AutoscalingRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			},
 		)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			RateLimiter:             r.WorkqueueRateLimiter,
+		}).
 		Complete(r)
 }
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -55,6 +56,7 @@ type EphemeralRunnerSetReconciler struct {
 	PublishMetrics bool
 
 	MaxConcurrentReconciles int
+	WorkqueueRateLimiter    workqueue.RateLimiter
 
 	ResourceBuilder
 }
@@ -578,7 +580,10 @@ func (r *EphemeralRunnerSetReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		For(&v1alpha1.EphemeralRunnerSet{}).
 		Owns(&v1alpha1.EphemeralRunner{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
+			RateLimiter:             r.WorkqueueRateLimiter,
+		}).
 		Complete(r)
 }
 


### PR DESCRIPTION
We observed that many EpehemralRunners were waiting for reconciliation after a JITConfig secret was created. This is likely because the next reconciliation is not enqueued by returning `Result{Requeue: true}` and such requeued reconciliations are rate limited by the workqueue rate limiter.
https://github.com/actions/actions-runner-controller/blob/8b36ea90ebe81710fcdcb4f96424b43203d24f1e/controllers/actions.github.com/ephemeralrunner_controller.go#L681-L682

The default rate limiter is defined by a combination of `NewTypedItemExponentialFailureRateLimiter` and `TypedBucketRateLimiter`.
https://github.com/kubernetes/client-go/blob/37045084c2aa82927b0e5ffc752861430fd7e4ab/util/workqueue/default_rate_limiters.go#L50-L56

This PR adds an option for disabling the `TypedBucketRateLimiter`.