### PR TITLE
gha: Enable secrets and configmaps caching in default mode

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_cluster_role.yaml
@@ -127,6 +127,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -177,7 +177,7 @@ func TestTemplate_CreateManagerClusterRole(t *testing.T) {
 
 	assert.Empty(t, managerClusterRole.Namespace, "ClusterRole should not have a namespace")
 	assert.Equal(t, "test-arc-gha-rs-controller", managerClusterRole.Name)
-	assert.Equal(t, 16, len(managerClusterRole.Rules))
+	assert.Equal(t, 18, len(managerClusterRole.Rules))
 
 	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/manager_single_namespace_controller_role.yaml"})
 	assert.ErrorContains(t, err, "could not find template templates/manager_single_namespace_controller_role.yaml in chart", "We should get an error because the template should be skipped")

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/actions/actions-runner-controller/github/actions"
 	"github.com/actions/actions-runner-controller/logging"
 	"github.com/kelseyhightower/envconfig"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -238,16 +237,6 @@ func main() {
 	cfg.QPS = float32(rateLimiterQPS)
 	cfg.Burst = rateLimiterBurst
 
-	clientOptions := client.Options{}
-	if watchSingleNamespace == "" {
-		clientOptions.Cache = &client.CacheOptions{
-			DisableFor: []client.Object{
-				&corev1.Secret{},
-				&corev1.ConfigMap{},
-			},
-		}
-	}
-
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -260,7 +249,7 @@ func main() {
 		WebhookServer:    webhookServer,
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: leaderElectionId,
-		Client:           clientOptions,
+		Client:           client.Options{},
 		PprofBindAddress: pprofAddr,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove the condition that disabled secrets and configmaps caching when watchSingleNamespace is empty
- Add necessary RBAC permissions for secrets and configmaps to gha-runner-scale-set-controller
- Allow all objects to be cached consistently in both single namespace and default modes

## Changes
- Remove cache disable logic for secrets/configmaps in main.go
- Add secrets and configmaps list/watch permissions to cluster role
- Update test to reflect new permission count (16 -> 18 rules)

## Test plan
- [x] Helm template tests pass
- [ ] Integration tests with actual cluster
- [ ] Verify caching behavior in both modes